### PR TITLE
feat: general tweaks

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:icon="@mipmap/launcher_icon">
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -31,15 +31,10 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>

--- a/lib/identity_manager.dart
+++ b/lib/identity_manager.dart
@@ -17,6 +17,14 @@ class IdentityManager {
 
   IdentityManager._();
 
+  Future<void> initFromStorage() async {
+    _accessToken = await _storage.read(key: 'access_token');
+    _refreshToken = await _storage.read(key: 'refresh_token');
+    _username = await _storage.read(key: 'username');
+    _userId = await _storage.read(key: 'id');
+    _email = await _storage.read(key: 'email');
+  }
+
   String? get accessToken => _accessToken;
   String? get refreshToken => _refreshToken;
   String? get username => _username;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,29 +6,43 @@ import 'screens/register.dart';
 import 'screens/home.dart';
 import 'screens/user.dart';
 import 'screens/information.dart';
-// import 'screens/sensor.dart';
 import 'screens/sensor/start.dart';
+import 'identity_manager.dart';
+import 'api.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 Future main() async {
   await dotenv.load();
-  runApp(const MyApp());
+  bool isLoggedIn = false;
+  final identityManager = IdentityManager();
+  await identityManager.initFromStorage();
+  if (identityManager.accessToken != null) {
+    final Api api = Api();
+    final ApiResponse res = await api.me();
+    if (res.success) isLoggedIn = true;
+  }
+  runApp(MyApp(isLoggedIn: isLoggedIn));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final bool isLoggedIn;
+
+  const MyApp({super.key, required this.isLoggedIn});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Thirst Alert',
       theme: myTheme,
+      initialRoute: isLoggedIn ? '/home' : '/',
+      navigatorKey: navigatorKey,
       routes: {
         '/': (context) => const LoginScreen(),
         '/register':(context) => const RegisterScreen(),
         '/home': (context) => const HomeScreen(),
         '/user': (context) => const UserScreen(),
         '/information': (context) => InformationScreen(0),
-        // '/viewSensor': (context) => SensorScreen(),
         '/sensor/start': (context) => const SensorStart(),
       },
     );

--- a/lib/screens/auth.dart
+++ b/lib/screens/auth.dart
@@ -19,110 +19,115 @@ class LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 150),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            Image.asset(
-              'lib/assets/thirst-alert-logo.png',
-              height: 75.0,
-            ),
-
-            const SizedBox(height: 60),
-
-            TextField(
-              controller: _identityController,
-              decoration: const InputDecoration(
-                  label: Center(
-                  child: Text('USERNAME OR EMAIL'),  
-                ),
-                // errorText: _errorMessage.isNotEmpty ? _errorMessage : null,
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 150),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Image.asset(
+                'lib/assets/thirst-alert-logo.png',
+                height: 75.0,
               ),
-              textAlign: TextAlign.center,
-            ),
-
-            const SizedBox(height: 20),
-            
-            TextField(
-              controller: _passwordController,
-              textAlign: TextAlign.center,
-              decoration: InputDecoration(
-                  label: const Center(
-                  child: Text('PASSWORD'),
+      
+              const SizedBox(height: 60),
+      
+              TextField(
+                controller: _identityController,
+                decoration: const InputDecoration(
+                    label: Center(
+                    child: Text('USERNAME OR EMAIL'),  
                   ),
-                  suffixIcon: IconButton(
-                    icon: Icon(_passwordIsObscured ? Icons.visibility : Icons.visibility_off),
-                    onPressed: () => setState(() {
-                      _passwordIsObscured = !_passwordIsObscured;
-                    }
-                  ),
+                  // errorText: _errorMessage.isNotEmpty ? _errorMessage : null,
                 ),
-                contentPadding: const EdgeInsets.fromLTRB(48, 16, 0, 16),
+                textAlign: TextAlign.center,
+                textInputAction: TextInputAction.next
               ),
-              obscureText: _passwordIsObscured,
-            ),
-          ],
+      
+              const SizedBox(height: 20),
+              
+              TextField(
+                controller: _passwordController,
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                    label: const Center(
+                    child: Text('PASSWORD'),
+                    ),
+                    suffixIcon: IconButton(
+                      icon: Icon(_passwordIsObscured ? Icons.visibility : Icons.visibility_off),
+                      onPressed: () => setState(() {
+                        _passwordIsObscured = !_passwordIsObscured;
+                      }
+                    ),
+                  ),
+                  contentPadding: const EdgeInsets.fromLTRB(48, 16, 0, 16),
+                ),
+                obscureText: _passwordIsObscured,
+                onSubmitted: (_) => onLogin(),
+              ),
+            ],
+          ),
         ),
-      ),
-
-      floatingActionButton: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            ElevatedButton (
-              onPressed: onLogin,
-              child: const Text('LOGIN'),
+      
+        floatingActionButton: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              ElevatedButton (
+                onPressed: onLogin,
+                child: const Text('LOGIN'),
+                ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: onRegister,
+                child: const Text('REGISTER'),
               ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: onRegister,
-              child: const Text('REGISTER'),
-            ),
-            const SizedBox(height: 10),
-            TextButton(
-              onPressed: () {
-                showDialog(
-                  context: context,
-                  barrierDismissible: false,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      actionsAlignment: MainAxisAlignment.center,
-                      content: SingleChildScrollView(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: <Widget>[
-                              const SizedBox(height: 20),
-                              TextField(
-                                controller: _identityController,
-                                textAlign: TextAlign.center,
-                                decoration: const InputDecoration(
-                                  label: Center(
-                                    child: Text('ACCOUNT EMAIL'),)
+              const SizedBox(height: 10),
+              TextButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        actionsAlignment: MainAxisAlignment.center,
+                        content: SingleChildScrollView(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: <Widget>[
+                                const SizedBox(height: 20),
+                                TextField(
+                                  controller: _identityController,
+                                  textAlign: TextAlign.center,
+                                  decoration: const InputDecoration(
+                                    label: Center(
+                                      child: Text('ACCOUNT EMAIL'),)
+                                  ),
                                 ),
-                              ),
-                            ],
-                          )
-                      ),
-                      actions: <Widget>[
-                        TextButton(
-                          onPressed: onResetPassword,
-                          child: const Text('RESET PASSWORD'),
+                              ],
+                            )
                         ),
-                      ],
-                    );
-                  },
-                );
-              },
-              child: const Text('RESET MY PASSWORD'),
-            ),
-            const SizedBox(height: 20)
-          ],          
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: onResetPassword,
+                            child: const Text('RESET PASSWORD'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                child: const Text('RESET MY PASSWORD'),
+              ),
+              const SizedBox(height: 20)
+            ],          
+          ),
+          floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
         ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      );
+    );
     }
 
   void onLogin() {
@@ -134,7 +139,7 @@ class LoginScreenState extends State<LoginScreen> {
           Navigator.pushNamed(context, '/home');
         } else {
           String errorMessage = response.error ?? 'An unknown error occurred';
-          if (errorMessage.contains('Forbidden: Email not verified')) {
+          if (errorMessage.contains('Email not verified')) {
             showDialog(
               context: context,
               builder: (BuildContext context) {
@@ -151,6 +156,7 @@ class LoginScreenState extends State<LoginScreen> {
                         TextField(
                           controller: _verificationTokenController,
                           textAlign: TextAlign.center,
+                          onSubmitted: (_) => onVerify(),
                         ),
                       ]
                     )
@@ -170,14 +176,24 @@ class LoginScreenState extends State<LoginScreen> {
       });
     }
 
-  void onVerify() async {
+  void onVerify() {
     api.verify({
-      'token': _verificationTokenController.text,
-      'identity': _identityController.text,
+    'token': _verificationTokenController.text,
+    'identity': _identityController.text,
     }).then((response) {
       if (response.success) {
-        Navigator.pushNamed(context, '/home');
-        Success.show(context, 'Welcome to Thirst Alert!');
+        api.login({
+          'identity': _identityController.text,
+          'password': _passwordController.text,
+        }).then((response) {
+          if (response.success) {
+            Navigator.pushNamed(context, '/home');
+            Success.show(context, 'Welcome to Thirst Alert!');
+          } else {
+            String errorMessage = response.error ?? 'An unknown error occurred';
+            Error.show(context, errorMessage);
+          }
+        });
       } else {
         String errorMessage = response.error ?? 'An unknown verification error occurred';
         Error.show(context, errorMessage);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -56,93 +56,96 @@ class HomeScreenState extends State<HomeScreen> {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Hello, ${identityManager.username ?? ''}'),
-        leading: Builder(
-          builder: (BuildContext context) {
-            return IconButton(
-              icon: const Icon(Icons.menu_rounded),
-              onPressed: () {
-                Navigator.pushNamed(context, '/user');
-              },
-            );
-          },
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout_rounded),
-            onPressed: onLogout,
-          ),
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 45),
-        child: Column(
-          children: [
-            Expanded(
-              child: GridView.builder(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  crossAxisSpacing: 10.0,
-                  mainAxisSpacing: 10.0,
-                ),
-                itemCount: mySensors!.length,
-                itemBuilder: (context, index) {
-                  final sensor = mySensors![index];
-                  return GestureDetector(
-                      onTap: () {
-                        onViewSensor(sensor);
-                      },
-                      child: SizedBox(
-                        child: Card(
-                        elevation: 3,
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(16.0),
-                          child: Column(
-                            children: [
-                              Expanded(
-                                child: sensor.isImageLoading
-                                  ? const Center(child: CircularProgressIndicator())
-                                  : Container(
-                                      decoration: BoxDecoration(
-                                        image: DecorationImage(
-                                          image: sensor.image,
-                                          fit: BoxFit.cover
-                                        ),
-                                      ),
-                                    )
-                              ),
-                              ListTile(
-                                title: Text(sensor.name),
-                                trailing: sensor.active == true 
-                                ? const Icon(Icons.favorite, color: accent) 
-                                : const Icon(Icons.water_drop, color: attention),
-                              ),
-                            ],
-                          ),
-                        )
-                      )
-                    )
-                  );
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('Hello, ${identityManager.username ?? ''}'),
+          leading: Builder(
+            builder: (BuildContext context) {
+              return IconButton(
+                icon: const Icon(Icons.menu_rounded),
+                onPressed: () {
+                  Navigator.pushNamed(context, '/user');
                 },
-              ),
-            ),
-            SizedBox(
-              height: 60,
-              width: 60,
-              child: ElevatedButton(
-                onPressed: onAddSensor,
-                style: ElevatedButton.styleFrom(padding: EdgeInsets.zero),
-                child: const Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(Icons.add),
-                  ],
-                ),
-              ),
+              );
+            },
+          ),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.logout_rounded),
+              onPressed: onLogout,
             ),
           ],
+        ),
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 45),
+          child: Column(
+            children: [
+              Expanded(
+                child: GridView.builder(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 10.0,
+                    mainAxisSpacing: 10.0,
+                  ),
+                  itemCount: mySensors!.length,
+                  itemBuilder: (context, index) {
+                    final sensor = mySensors![index];
+                    return GestureDetector(
+                        onTap: () {
+                          onViewSensor(sensor);
+                        },
+                        child: SizedBox(
+                          child: Card(
+                          elevation: 3,
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(16.0),
+                            child: Column(
+                              children: [
+                                Expanded(
+                                  child: sensor.isImageLoading
+                                    ? const Center(child: CircularProgressIndicator())
+                                    : Container(
+                                        decoration: BoxDecoration(
+                                          image: DecorationImage(
+                                            image: sensor.image,
+                                            fit: BoxFit.cover
+                                          ),
+                                        ),
+                                      )
+                                ),
+                                ListTile(
+                                  title: Text(sensor.name),
+                                  trailing: sensor.active == true 
+                                  ? const Icon(Icons.favorite, color: accent) 
+                                  : const Icon(Icons.water_drop, color: attention),
+                                ),
+                              ],
+                            ),
+                          )
+                        )
+                      )
+                    );
+                  },
+                ),
+              ),
+              SizedBox(
+                height: 60,
+                width: 60,
+                child: ElevatedButton(
+                  onPressed: onAddSensor,
+                  style: ElevatedButton.styleFrom(padding: EdgeInsets.zero),
+                  child: const Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.add),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/register.dart
+++ b/lib/screens/register.dart
@@ -76,12 +76,14 @@ class RegisterScreenState extends State<RegisterScreen> {
                 ),
                 counterText: '',
               ),
+              textInputAction: TextInputAction.next
             ),
 
             const SizedBox(height: 20),
 
             TextField(
               controller: _emailController,
+              keyboardType: TextInputType.emailAddress,
               onChanged: (text) {
                 _emailController.text = text.toLowerCase();
                 setState(() {
@@ -96,6 +98,7 @@ class RegisterScreenState extends State<RegisterScreen> {
                 errorMaxLines: 2,
                 errorText: validEmail ? null : 'Please enter a valid email address',
               ),
+              textInputAction: TextInputAction.next
             ),
 
             const SizedBox(height: 20),
@@ -127,6 +130,7 @@ class RegisterScreenState extends State<RegisterScreen> {
                 contentPadding: const EdgeInsets.fromLTRB(48, 16, 0, 16),
               ),
               obscureText: _passwordIsObscured,
+              textInputAction: TextInputAction.next
             ),
 
             const SizedBox(height: 20),
@@ -149,6 +153,9 @@ class RegisterScreenState extends State<RegisterScreen> {
                 contentPadding: const EdgeInsets.fromLTRB(48, 16, 0, 16),
               ),
               obscureText: _passwordIsObscured,
+              onSubmitted: (_) {
+                if (validEmail && validPassword) return onRegister();
+              },
             ),
             const SizedBox(height: 350),
           ],
@@ -219,6 +226,7 @@ class RegisterScreenState extends State<RegisterScreen> {
                     TextField(
                       controller: _verificationTokenController,
                       textAlign: TextAlign.center,
+                      onSubmitted: (_) => onVerify(),
                     ),
                   ],
                 )
@@ -245,8 +253,18 @@ class RegisterScreenState extends State<RegisterScreen> {
     'identity': _emailController.text,
     }).then((response) {
       if (response.success) {
-        Navigator.pushNamed(context, '/home');
-        Success.show(context, 'Welcome to Thirst Alert!');
+        api.login({
+          'identity': _emailController.text,
+          'password': _passwordController.text,
+        }).then((response) {
+          if (response.success) {
+            Navigator.pushNamed(context, '/home');
+            Success.show(context, 'Welcome to Thirst Alert!');
+          } else {
+            String errorMessage = response.error ?? 'An unknown error occurred';
+            Error.show(context, errorMessage);
+          }
+        });
       } else {
         String errorMessage = response.error ?? 'An unknown verification error occurred';
         Error.show(context, errorMessage);

--- a/lib/screens/sensor/measurement.dart
+++ b/lib/screens/sensor/measurement.dart
@@ -1,4 +1,3 @@
-//import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
@@ -211,7 +210,7 @@ class SensorChartState extends State<SensorChart> {
   Api api = Api();
 
   Future<void> fetchDataWeek() async {
-    api.getMeasurementsWeek(widget.sensorId).then((response) {
+    api.getMeasurements(widget.sensorId, 'week').then((response) {
       if (response.success) {
         final measurementWeekData = response.data;
         setState(() {
@@ -224,7 +223,7 @@ class SensorChartState extends State<SensorChart> {
   }
   
   Future<void> fetchDataMonth() async {
-    api.getMeasurementsMonth(widget.sensorId).then((response) {
+    api.getMeasurements(widget.sensorId, 'month').then((response) {
       if (response.success) {
         final measurementMonthData = response.data;
         setState(() {


### PR DESCRIPTION
- use new getMeasurements route
- force portrait mode
- check authentication on app startup (aka no more re-login on shift-r while developing ✨)
- disallow swipe navigation from login to homepage (after a logout for example) and from homepage to login (after a login for example) with the PopScope widget. let's test it with these routes on android too and see how it looks like
- completed logout functionality
- completed register functionality (loads identity data in identity manager and loads homepage)
- made tweaks to the login and register pages: 
  1. submit button on keyboard: using the submit button on the keyboard either focuses the next input field or submits the 
    form. doesn't really work well on the register screen, with the repeat password field. i think because of the fields being 
    covered by the keyboard. done the same thing to the verify email code thing dialog.
  2. when focusing the email field in the register screen, it shows a email type keyboard with easily accessible `.`, `@`, etc..
  
**EDIT**:
- fixed bugs with api abstraction
  1. now it should never hang if a request returns a response that is not "standard".
  2. when the refresh token expires, the user is brought back to the login screen and user data is cleared
